### PR TITLE
switching deparse() to deparse1() in jlmer() function definition

### DIFF
--- a/R/JellyMe4.R
+++ b/R/JellyMe4.R
@@ -71,7 +71,7 @@ jmer <- function(formula, data, REML=TRUE){
     # Also, this means we suffer/benefit from the same level of compatibility in
     # the formula as in JellyMe4, i.e. currently no support for the ||
 
-    jf <- deparse(formula)
+    jf <- deparse1(formula)
     jreml = ifelse(REML, "true", "false")
 
     julia_assign("jmerdat",data)


### PR DESCRIPTION
`jlmer()` uses `deparse()` so that the model formula can be passed from R to Julia as a string, but `deparse()` has this annoying `width.cutoff` parameter that by default cuts any formula of more than 60 characters into multiple strings.

Passing an array of strings to `MixedModels.jl` as a model formula unsurprisingly starts several small fires in your `JuliaCall` session, and most non-trivial model formulas probably exceed 60 characters, so this is a problem that needs a fix.

Replacing `deparse()` with `deparse1()` defaults the max formula length to 500 characters, which should be sufficient in for most use-cases.